### PR TITLE
Remove information about return policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,6 @@ about a problem reported within the first 7 days of ownership and being asked to
 > Note: the information about refusing delivery and reporting delivery issues has been
 > contributed by several people. I couldn't find the authoritative source; pointers appreciated. 
 
-- As a last resort you have [7 calendar days/1000 miles](https://www.tesla.com/support/tesla-return-policy) to **return the car**
-(here's a [first-hand account](https://www.reddit.com/r/TeslaModelY/comments/heb5cu/i_changed_my_mind_im_returning_my_model_y/)).
-Note that doing so restricts your next Tesla order: "If you decide to order another vehicle, you may not order the same trim for
-a period of 12 months but may order another vehicle in a different trim at any time."
-
 ## Ownership beyond the first 1,000 miles
 
 Making it past the above milestones doesn't mean that SC visits or Mobile Service appointments are a thing of the past. Remaining problems caused by


### PR DESCRIPTION
Tesla removed it's return policy: https://www.businessinsider.com/teslas-7-day-return-policy-appears-to-have-been-killed-2020-10#:~:text=As%20recently%20as%20September%2030,within%20seven%20(7)%20calendar%20days